### PR TITLE
Revert FrEIA repo to commit before submission

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ packages = [
 # Requirements
 [tool.poetry.dependencies]
 python = ">=3.8"
-FrEIA = { git = "https://github.com/VLL-HD/FrEIA.git" }
+FrEIA = { git = "https://github.com/VLL-HD/FrEIA.git@31ef2b8f75ad73548bb3463970ba334012813540" }
 click = "*"
 Sphinx = "*"
 coverage = "*"


### PR DESCRIPTION
Currently, the model weights saved for submission can not be loaded into the code because of new changes in the FrEIA repository. I'm reverting the requirements in the pyproject.toml to the status before the submission